### PR TITLE
fix: handle multi-line JSX elements correctly when inserting attributes

### DIFF
--- a/src/__tests__/multi-line-jsx.test.ts
+++ b/src/__tests__/multi-line-jsx.test.ts
@@ -201,4 +201,88 @@ describe('Multi-line JSX Element Handling', () => {
       expect(result.code).toMatch(/data-dev-name="div"[^>]*data-dev-line="3"/);
     }
   });
+
+  it('should handle JSX elements with spaces before closing brackets', async () => {
+    const plugin = componentDebugger();
+    const code = `function SpacesExample() {
+  return (
+    <div className="with-space" >
+      <input type="text" disabled />
+      <CustomComponent
+        prop1="value1"
+        prop2="value2"
+        />
+      <AnotherComponent prop="value"   />
+    </div>
+  );
+}`;
+
+    const result = await plugin.transform?.(code, 'Spaces.tsx');
+    
+    if (result && typeof result === 'object' && 'code' in result) {
+      // Verify syntax is valid
+      expect(() => {
+        const babel = require('@babel/parser');
+        babel.parse(result.code, {
+          sourceType: 'module',
+          plugins: ['jsx', 'typescript']
+        });
+      }).not.toThrow();
+      
+      // Verify all elements are tagged
+      expect(result.code).toContain('data-dev-name="div"');
+      expect(result.code).toContain('data-dev-name="input"');
+      expect(result.code).toContain('data-dev-name="CustomComponent"');
+      expect(result.code).toContain('data-dev-name="AnotherComponent"');
+      
+      // Verify the original formatting is preserved (spaces may be adjusted due to attribute insertion)
+      expect(result.code).toContain('className="with-space"');
+      expect(result.code).toContain('disabled');
+      expect(result.code).toContain('prop="value"');
+    }
+  });
+
+  it('should handle JSX elements with newlines before closing brackets', async () => {
+    const plugin = componentDebugger();
+    const code = `function NewlinesExample() {
+  return (
+    <div
+      className="container"
+    >
+      <input
+        type="text"
+        placeholder="Enter text"
+      />
+      <CustomComponent
+        prop1="value1"
+        prop2="value2"
+        
+      />
+    </div>
+  );
+}`;
+
+    const result = await plugin.transform?.(code, 'Newlines.tsx');
+    
+    if (result && typeof result === 'object' && 'code' in result) {
+      // Verify syntax is valid
+      expect(() => {
+        const babel = require('@babel/parser');
+        babel.parse(result.code, {
+          sourceType: 'module',
+          plugins: ['jsx', 'typescript']
+        });
+      }).not.toThrow();
+      
+      // Verify all elements are tagged
+      expect(result.code).toContain('data-dev-name="div"');
+      expect(result.code).toContain('data-dev-name="input"');
+      expect(result.code).toContain('data-dev-name="CustomComponent"');
+      
+      // Verify line numbers are correct
+      expect(result.code).toMatch(/data-dev-name="div"[^>]*data-dev-line="3"/);
+      expect(result.code).toMatch(/data-dev-name="input"[^>]*data-dev-line="6"/);
+      expect(result.code).toMatch(/data-dev-name="CustomComponent"[^>]*data-dev-line="10"/);
+    }
+  });
 });

--- a/src/__tests__/multi-line-jsx.test.ts
+++ b/src/__tests__/multi-line-jsx.test.ts
@@ -1,0 +1,204 @@
+// src/__tests__/multi-line-jsx.test.ts
+import { describe, it, expect } from 'vitest';
+import { componentDebugger } from '../plugin';
+
+describe('Multi-line JSX Element Handling', () => {
+  it('should correctly handle multi-line JSX elements with attributes', async () => {
+    const plugin = componentDebugger();
+    const code = `export function TreeSelectExample() {
+  return (
+    <TreeSelect
+      getItemId={(item) => item.guid}
+      getItemChildren={(item) => item.children}
+      onSelect={(item) => console.log(item)}
+      className="tree-select-container"
+    >
+      <TreeItem value="1">Item 1</TreeItem>
+    </TreeSelect>
+  );
+}`;
+
+    const result = await plugin.transform?.(code, 'TreeSelect.tsx');
+    
+    if (result && typeof result === 'object' && 'code' in result) {
+      // Check that the code is valid JavaScript/JSX
+      expect(() => {
+        // This would throw if the syntax is invalid
+        const babel = require('@babel/parser');
+        babel.parse(result.code, {
+          sourceType: 'module',
+          plugins: ['jsx', 'typescript']
+        });
+      }).not.toThrow();
+      
+      // Verify attributes are added
+      expect(result.code).toContain('data-dev-name="TreeSelect"');
+      expect(result.code).toContain('data-dev-name="TreeItem"');
+      
+      // Verify the original attributes are preserved
+      expect(result.code).toContain('getItemId={(item) => item.guid}');
+      expect(result.code).toContain('getItemChildren={(item) => item.children}');
+      expect(result.code).toContain('className="tree-select-container"');
+      
+      // Verify line numbers
+      expect(result.code).toMatch(/data-dev-name="TreeSelect"[^>]*data-dev-line="3"/);
+      expect(result.code).toMatch(/data-dev-name="TreeItem"[^>]*data-dev-line="9"/);
+    }
+  });
+
+  it('should handle self-closing multi-line JSX elements', async () => {
+    const plugin = componentDebugger();
+    const code = `function SelfClosingExample() {
+  return (
+    <CustomInput
+      type="text"
+      placeholder="Enter text"
+      onChange={(e) => console.log(e.target.value)}
+      className="input-field"
+      disabled={false}
+    />
+  );
+}`;
+
+    const result = await plugin.transform?.(code, 'SelfClosing.tsx');
+    
+    if (result && typeof result === 'object' && 'code' in result) {
+      // Verify syntax is valid
+      expect(() => {
+        const babel = require('@babel/parser');
+        babel.parse(result.code, {
+          sourceType: 'module',
+          plugins: ['jsx', 'typescript']
+        });
+      }).not.toThrow();
+      
+      // Verify attributes are added
+      expect(result.code).toContain('data-dev-name="CustomInput"');
+      expect(result.code).toMatch(/data-dev-name="CustomInput"[^>]*data-dev-line="3"/);
+      
+      // Verify it's still self-closing
+      expect(result.code).toContain('/>');
+      
+      // Ensure attributes are inserted before the self-closing tag
+      const regex = /data-dev-component="CustomInput"\/>/;
+      expect(result.code).toMatch(regex);
+    }
+  });
+
+  it('should handle JSX elements with spread attributes', async () => {
+    const plugin = componentDebugger();
+    const code = `function SpreadExample() {
+  const props = { className: 'btn', onClick: () => {} };
+  
+  return (
+    <button
+      {...props}
+      id="submit-btn"
+      disabled
+    >
+      Submit
+    </button>
+  );
+}`;
+
+    const result = await plugin.transform?.(code, 'Spread.tsx');
+    
+    if (result && typeof result === 'object' && 'code' in result) {
+      // Verify syntax is valid
+      expect(() => {
+        const babel = require('@babel/parser');
+        babel.parse(result.code, {
+          sourceType: 'module',
+          plugins: ['jsx', 'typescript']
+        });
+      }).not.toThrow();
+      
+      // Verify attributes are added
+      expect(result.code).toContain('data-dev-name="button"');
+      expect(result.code).toMatch(/data-dev-name="button"[^>]*data-dev-line="5"/);
+      
+      // Verify spread is preserved
+      expect(result.code).toContain('{...props}');
+    }
+  });
+
+  it('should handle JSX elements with complex nested attributes', async () => {
+    const plugin = componentDebugger();
+    const code = `function ComplexAttributes() {
+  return (
+    <Component
+      style={{
+        backgroundColor: 'red',
+        padding: '10px',
+        margin: '5px'
+      }}
+      data={{
+        items: [1, 2, 3],
+        config: {
+          enabled: true
+        }
+      }}
+      render={(item) => (
+        <div>{item}</div>
+      )}
+    />
+  );
+}`;
+
+    const result = await plugin.transform?.(code, 'Complex.tsx');
+    
+    if (result && typeof result === 'object' && 'code' in result) {
+      // Verify syntax is valid
+      expect(() => {
+        const babel = require('@babel/parser');
+        babel.parse(result.code, {
+          sourceType: 'module',
+          plugins: ['jsx', 'typescript']
+        });
+      }).not.toThrow();
+      
+      // Verify attributes are added to both Component and the div in render
+      expect(result.code).toContain('data-dev-name="Component"');
+      expect(result.code).toContain('data-dev-name="div"');
+      
+      // Verify line numbers
+      expect(result.code).toMatch(/data-dev-name="Component"[^>]*data-dev-line="3"/);
+      expect(result.code).toMatch(/data-dev-name="div"[^>]*data-dev-line="16"/);
+    }
+  });
+
+  it('should handle JSX elements with comments between attributes', async () => {
+    const plugin = componentDebugger();
+    const code = `function WithComments() {
+  return (
+    <div
+      className="container"
+      // This is a comment
+      onClick={() => {}}
+      /* Multi-line
+         comment */
+      style={{ color: 'blue' }}
+    >
+      Content
+    </div>
+  );
+}`;
+
+    const result = await plugin.transform?.(code, 'Comments.tsx');
+    
+    if (result && typeof result === 'object' && 'code' in result) {
+      // Verify syntax is valid
+      expect(() => {
+        const babel = require('@babel/parser');
+        babel.parse(result.code, {
+          sourceType: 'module',
+          plugins: ['jsx', 'typescript']
+        });
+      }).not.toThrow();
+      
+      // Verify attributes are added
+      expect(result.code).toContain('data-dev-name="div"');
+      expect(result.code).toMatch(/data-dev-name="div"[^>]*data-dev-line="3"/);
+    }
+  });
+});

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -313,7 +313,19 @@ export function componentDebugger(options: TagOptions = {}): Plugin {
               const attributes = generateAttributes(info, attributePrefix);
               
               // Insert attributes into the code
-              const insertPosition = openingElement.name.end ?? 0;
+              // For self-closing elements: <Component />
+              // For regular elements: <Component>
+              // We need to insert before the '>' or '/>'
+              let insertPosition: number;
+              
+              if (openingElement.selfClosing) {
+                // Self-closing element - insert before the '/>'
+                insertPosition = openingElement.end! - 2;
+              } else {
+                // Regular element - insert before the '>'
+                insertPosition = openingElement.end! - 1;
+              }
+              
               magicString.appendLeft(insertPosition, attributes);
               
               elementCount++;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
     "types": ["node", "vite/client"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts", "src/__tests__/fixtures/**/*"]
 }


### PR DESCRIPTION
## Summary
- Fixes "Invalid assignment target" error when using multi-line JSX elements
- Ensures data attributes are inserted at the correct position in JSX opening tags
- Preserves valid JSX syntax for both regular and self-closing elements

## Problem
The plugin was inserting data attributes immediately after the element name, which broke syntax for multi-line JSX elements:
```jsx
<TreeSelect
  data-dev-id="..." // incorrectly inserted here
  getItemId={(item) => item.guid}
  ...
>
```

## Solution
- Insert attributes before the closing `>` for regular elements
- Insert attributes before the closing `/>` for self-closing elements
- This ensures valid JSX syntax is maintained

## Test plan
- [x] Added comprehensive tests for multi-line JSX scenarios
- [x] Verified all existing tests still pass
- [x] Tested with self-closing elements
- [x] Tested with spread attributes
- [x] Tested with complex nested attributes
- [x] Tested with comments between attributes
- [x] Build succeeds without errors
- [x] TypeScript compilation passes

Fixes the issue reported by @ultrathink

🤖 Generated with [Claude Code](https://claude.ai/code)