### PR TITLE
feat: add includeAttributes and excludeAttributes options for filtering data attributes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,10 +105,16 @@ Main `TagOptions` interface:
 - `excludeElements` - Elements to skip (default: Fragment types)
 - `includeProps` - Capture component props in metadata (default: `false`)
 - `includeContent` - Include text content in metadata (default: `false`)
+- `includeAttributes` - Allowlist of attributes to include (default: `undefined`, all included)
+- `excludeAttributes` - Disallowlist of attributes to exclude (default: `undefined`, none excluded)
 - `customExcludes` - Custom element exclusions (default: Three.js elements)
 - `debug` - Enable debug logging for troubleshooting (default: `false`)
 
+**Available attribute names:** `'id'`, `'name'`, `'path'`, `'line'`, `'file'`, `'component'`, `'metadata'`
+
 **Performance Note**: By default, `data-dev-metadata` is disabled (`includeProps: false`, `includeContent: false`) for better build performance. Enable these options only when you need to capture props or content data.
+
+**Attribute Filtering**: Use `includeAttributes` to allowlist specific attributes (e.g., `['id', 'name']`) or `excludeAttributes` to disallowlist attributes (e.g., `['metadata', 'file']`). If both are specified, `includeAttributes` takes priority.
 
 ## Development Workflow
 

--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,11 @@ componentDebugger({
   includeProps: true, // Enable to capture component props in data-dev-metadata
   includeContent: true, // Enable to capture text content in data-dev-metadata
 
+  // Attribute filtering (control which data attributes are generated)
+  includeAttributes: ["id", "name", "line"], // Only include these attributes
+  // OR
+  excludeAttributes: ["metadata", "file"], // Exclude these attributes
+
   // Element exclusions
   excludeElements: ["Fragment", "React.Fragment"],
   customExcludes: new Set(["mesh", "group", "camera"]), // Three.js elements
@@ -137,15 +142,46 @@ componentDebugger({
 
 ### All Configuration Options
 
-| Option            | Type          | Default                          | Description                         |
-| ----------------- | ------------- | -------------------------------- | ----------------------------------- |
-| `enabled`         | `boolean`     | `true`                           | Enable/disable the plugin           |
-| `attributePrefix` | `string`      | `'data-dev'`                     | Prefix for data attributes          |
-| `extensions`      | `string[]`    | `['.jsx', '.tsx']`               | File extensions to process          |
-| `includeProps`    | `boolean`     | `false`                          | Include component props in metadata |
-| `includeContent`  | `boolean`     | `false`                          | Include text content in metadata    |
-| `excludeElements` | `string[]`    | `['Fragment', 'React.Fragment']` | Elements to exclude                 |
-| `customExcludes`  | `Set<string>` | Three.js elements                | Custom elements to exclude          |
+| Option               | Type                | Default                          | Description                                              |
+| -------------------- | ------------------- | -------------------------------- | -------------------------------------------------------- |
+| `enabled`            | `boolean`           | `true`                           | Enable/disable the plugin                                |
+| `attributePrefix`    | `string`            | `'data-dev'`                     | Prefix for data attributes                               |
+| `extensions`         | `string[]`          | `['.jsx', '.tsx']`               | File extensions to process                               |
+| `includeProps`       | `boolean`           | `false`                          | Include component props in metadata                      |
+| `includeContent`     | `boolean`           | `false`                          | Include text content in metadata                         |
+| `includeAttributes`  | `AttributeName[]`   | `undefined`                      | Allowlist: only include these attributes (takes priority)|
+| `excludeAttributes`  | `AttributeName[]`   | `undefined`                      | Disallowlist: exclude these attributes                   |
+| `excludeElements`    | `string[]`          | `['Fragment', 'React.Fragment']` | Elements to exclude                                      |
+| `customExcludes`     | `Set<string>`       | Three.js elements                | Custom elements to exclude                               |
+
+**Available attribute names:** `'id'`, `'name'`, `'path'`, `'line'`, `'file'`, `'component'`, `'metadata'`
+
+### Attribute Filtering Examples
+
+**Minimal setup (only include ID):**
+```typescript
+componentDebugger({
+  includeAttributes: ["id"], // Only generates data-dev-id
+});
+// Result: <button data-dev-id="src/Button.tsx:10:2">Click me</button>
+```
+
+**Exclude clutter (remove verbose attributes):**
+```typescript
+componentDebugger({
+  excludeAttributes: ["metadata", "file", "component"], // Exclude these
+});
+// Result: <button data-dev-id="..." data-dev-name="button" data-dev-path="..." data-dev-line="10">
+```
+
+**Testing setup (only what you need):**
+```typescript
+componentDebugger({
+  includeAttributes: ["id", "name", "component"], // Minimal for testing
+});
+```
+
+> **Note:** When both `includeAttributes` and `excludeAttributes` are specified, `includeAttributes` takes priority.
 
 ## Use Cases
 

--- a/src/__tests__/attribute-filtering.test.ts
+++ b/src/__tests__/attribute-filtering.test.ts
@@ -1,0 +1,306 @@
+// src/__tests__/attribute-filtering.test.ts
+import { describe, it, expect } from 'vitest';
+import { componentDebugger } from '../plugin';
+
+describe('Attribute Filtering', () => {
+  const basicCode = `
+    export function Button() {
+      return <button className="btn">Click me</button>;
+    }
+  `;
+
+  describe('includeAttributes (allowlist)', () => {
+    it('should only include specified attributes when using allowlist', async () => {
+      const plugin = componentDebugger({
+        includeAttributes: ['id', 'name']
+      });
+
+      const result = await plugin.transform?.(basicCode, 'Button.tsx');
+
+      if (result && typeof result === 'object' && 'code' in result) {
+        // Should include
+        expect(result.code).toContain('data-dev-id');
+        expect(result.code).toContain('data-dev-name');
+
+        // Should NOT include
+        expect(result.code).not.toContain('data-dev-path');
+        expect(result.code).not.toContain('data-dev-line');
+        expect(result.code).not.toContain('data-dev-file');
+        expect(result.code).not.toContain('data-dev-component');
+        expect(result.code).not.toContain('data-dev-metadata');
+      }
+    });
+
+    it('should only include id when specified', async () => {
+      const plugin = componentDebugger({
+        includeAttributes: ['id']
+      });
+
+      const result = await plugin.transform?.(basicCode, 'Button.tsx');
+
+      if (result && typeof result === 'object' && 'code' in result) {
+        expect(result.code).toContain('data-dev-id');
+        expect(result.code).not.toContain('data-dev-name');
+        expect(result.code).not.toContain('data-dev-path');
+        expect(result.code).not.toContain('data-dev-line');
+      }
+    });
+
+    it('should work with line and file attributes', async () => {
+      const plugin = componentDebugger({
+        includeAttributes: ['line', 'file', 'path']
+      });
+
+      const result = await plugin.transform?.(basicCode, 'Button.tsx');
+
+      if (result && typeof result === 'object' && 'code' in result) {
+        expect(result.code).toContain('data-dev-line');
+        expect(result.code).toContain('data-dev-file');
+        expect(result.code).toContain('data-dev-path');
+        expect(result.code).not.toContain('data-dev-id');
+        expect(result.code).not.toContain('data-dev-name');
+      }
+    });
+
+    it('should handle metadata attribute when props are enabled', async () => {
+      const plugin = componentDebugger({
+        includeAttributes: ['id', 'metadata'],
+        includeProps: true
+      });
+
+      const codeWithProps = `
+        export function Button() {
+          return <button className="primary" disabled>Click</button>;
+        }
+      `;
+
+      const result = await plugin.transform?.(codeWithProps, 'Button.tsx');
+
+      if (result && typeof result === 'object' && 'code' in result) {
+        expect(result.code).toContain('data-dev-id');
+        expect(result.code).toContain('data-dev-metadata');
+        expect(result.code).not.toContain('data-dev-name');
+        expect(result.code).not.toContain('data-dev-path');
+      }
+    });
+
+    it('should not include metadata when not in allowlist even if includeProps is true', async () => {
+      const plugin = componentDebugger({
+        includeAttributes: ['id', 'name'],
+        includeProps: true
+      });
+
+      const codeWithProps = `
+        export function Button() {
+          return <button className="primary">Click</button>;
+        }
+      `;
+
+      const result = await plugin.transform?.(codeWithProps, 'Button.tsx');
+
+      if (result && typeof result === 'object' && 'code' in result) {
+        expect(result.code).toContain('data-dev-id');
+        expect(result.code).toContain('data-dev-name');
+        expect(result.code).not.toContain('data-dev-metadata');
+      }
+    });
+  });
+
+  describe('excludeAttributes (disallowlist)', () => {
+    it('should exclude specified attributes when using disallowlist', async () => {
+      const plugin = componentDebugger({
+        excludeAttributes: ['metadata', 'file', 'component']
+      });
+
+      const result = await plugin.transform?.(basicCode, 'Button.tsx');
+
+      if (result && typeof result === 'object' && 'code' in result) {
+        // Should include
+        expect(result.code).toContain('data-dev-id');
+        expect(result.code).toContain('data-dev-name');
+        expect(result.code).toContain('data-dev-path');
+        expect(result.code).toContain('data-dev-line');
+
+        // Should NOT include
+        expect(result.code).not.toContain('data-dev-file');
+        expect(result.code).not.toContain('data-dev-component');
+        expect(result.code).not.toContain('data-dev-metadata');
+      }
+    });
+
+    it('should exclude only id when specified', async () => {
+      const plugin = componentDebugger({
+        excludeAttributes: ['id']
+      });
+
+      const result = await plugin.transform?.(basicCode, 'Button.tsx');
+
+      if (result && typeof result === 'object' && 'code' in result) {
+        expect(result.code).not.toContain('data-dev-id');
+        expect(result.code).toContain('data-dev-name');
+        expect(result.code).toContain('data-dev-path');
+        expect(result.code).toContain('data-dev-line');
+      }
+    });
+
+    it('should exclude name and component attributes', async () => {
+      const plugin = componentDebugger({
+        excludeAttributes: ['name', 'component']
+      });
+
+      const result = await plugin.transform?.(basicCode, 'Button.tsx');
+
+      if (result && typeof result === 'object' && 'code' in result) {
+        expect(result.code).toContain('data-dev-id');
+        expect(result.code).not.toContain('data-dev-name');
+        expect(result.code).not.toContain('data-dev-component');
+        expect(result.code).toContain('data-dev-path');
+      }
+    });
+  });
+
+  describe('Priority and edge cases', () => {
+    it('should prioritize includeAttributes over excludeAttributes', async () => {
+      const plugin = componentDebugger({
+        includeAttributes: ['id', 'name'],
+        excludeAttributes: ['name', 'path'] // name is in both, should be included
+      });
+
+      const result = await plugin.transform?.(basicCode, 'Button.tsx');
+
+      if (result && typeof result === 'object' && 'code' in result) {
+        expect(result.code).toContain('data-dev-id');
+        expect(result.code).toContain('data-dev-name'); // Should be included due to allowlist
+        expect(result.code).not.toContain('data-dev-path');
+        expect(result.code).not.toContain('data-dev-line');
+      }
+    });
+
+    it('should include all attributes when neither option is specified', async () => {
+      const plugin = componentDebugger();
+
+      const result = await plugin.transform?.(basicCode, 'Button.tsx');
+
+      if (result && typeof result === 'object' && 'code' in result) {
+        expect(result.code).toContain('data-dev-id');
+        expect(result.code).toContain('data-dev-name');
+        expect(result.code).toContain('data-dev-path');
+        expect(result.code).toContain('data-dev-line');
+        expect(result.code).toContain('data-dev-file');
+        expect(result.code).toContain('data-dev-component');
+      }
+    });
+
+    it('should handle empty includeAttributes array', async () => {
+      const plugin = componentDebugger({
+        includeAttributes: []
+      });
+
+      const result = await plugin.transform?.(basicCode, 'Button.tsx');
+
+      // Should still transform but with no attributes
+      if (result && typeof result === 'object' && 'code' in result) {
+        expect(result.code).not.toContain('data-dev-id');
+        expect(result.code).not.toContain('data-dev-name');
+        expect(result.code).toContain('Click me'); // Code should still be there
+      }
+    });
+
+    it('should handle empty excludeAttributes array', async () => {
+      const plugin = componentDebugger({
+        excludeAttributes: []
+      });
+
+      const result = await plugin.transform?.(basicCode, 'Button.tsx');
+
+      // Should include all attributes (empty disallowlist excludes nothing)
+      if (result && typeof result === 'object' && 'code' in result) {
+        expect(result.code).toContain('data-dev-id');
+        expect(result.code).toContain('data-dev-name');
+        expect(result.code).toContain('data-dev-path');
+      }
+    });
+  });
+
+  describe('Combined with other options', () => {
+    it('should work with custom attributePrefix', async () => {
+      const plugin = componentDebugger({
+        includeAttributes: ['id', 'name'],
+        attributePrefix: 'data-test'
+      });
+
+      const result = await plugin.transform?.(basicCode, 'Button.tsx');
+
+      if (result && typeof result === 'object' && 'code' in result) {
+        expect(result.code).toContain('data-test-id');
+        expect(result.code).toContain('data-test-name');
+        expect(result.code).not.toContain('data-dev-id');
+      }
+    });
+
+    it('should work with multiple elements', async () => {
+      const multiElementCode = `
+        export function Form() {
+          return (
+            <form>
+              <input type="text" />
+              <button>Submit</button>
+            </form>
+          );
+        }
+      `;
+
+      const plugin = componentDebugger({
+        includeAttributes: ['id', 'line']
+      });
+
+      const result = await plugin.transform?.(multiElementCode, 'Form.tsx');
+
+      if (result && typeof result === 'object' && 'code' in result) {
+        // Each element should have only id and line
+        const idMatches = result.code.match(/data-dev-id/g);
+        const lineMatches = result.code.match(/data-dev-line/g);
+        const nameMatches = result.code.match(/data-dev-name/g);
+
+        expect(idMatches).toHaveLength(3); // form, input, button
+        expect(lineMatches).toHaveLength(3);
+        expect(nameMatches).toBeNull();
+      }
+    });
+
+    it('should respect attribute filtering with includeProps and includeContent', async () => {
+      const plugin = componentDebugger({
+        includeAttributes: ['id', 'name', 'metadata'],
+        includeProps: true,
+        includeContent: true
+      });
+
+      const codeWithPropsAndContent = `
+        export function Button() {
+          return <button className="primary" disabled>Click me</button>;
+        }
+      `;
+
+      const result = await plugin.transform?.(codeWithPropsAndContent, 'Button.tsx');
+
+      if (result && typeof result === 'object' && 'code' in result) {
+        expect(result.code).toContain('data-dev-id');
+        expect(result.code).toContain('data-dev-name');
+        expect(result.code).toContain('data-dev-metadata');
+        expect(result.code).not.toContain('data-dev-path');
+        expect(result.code).not.toContain('data-dev-line');
+        expect(result.code).not.toContain('data-dev-file');
+
+        // Verify metadata contains props and content
+        const metadataMatch = result.code.match(/data-dev-metadata="([^"]+)"/);
+        if (metadataMatch) {
+          const decoded = decodeURIComponent(metadataMatch[1]);
+          const metadata = JSON.parse(decoded);
+          expect(metadata.className).toBe('primary');
+          expect(metadata.disabled).toBe(true);
+          expect(metadata.text).toBe('Click me');
+        }
+      }
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 // src/index.ts
 export { componentDebugger as default } from './plugin';
-export type { TagOptions } from './plugin';
+export type { TagOptions, AttributeName } from './plugin';
 


### PR DESCRIPTION
## Summary

Adds two new configuration options to control which data attributes get generated:
- **`includeAttributes`** - Allowlist: only include specified attributes
- **`excludeAttributes`** - Disallowlist: exclude specified attributes

This provides fine-grained control over the generated attributes, reducing DOM clutter when you only need specific attributes.

## Changes

### Core Implementation
- Added `AttributeName` type for type-safe attribute filtering
- Added `includeAttributes` and `excludeAttributes` options to `TagOptions`
- Modified `generateAttributes()` to filter attributes based on configuration
- `includeAttributes` takes priority when both options are specified
- **Fully backwards compatible** - default behavior unchanged when options not specified

### Available Attributes
`'id'`, `'name'`, `'path'`, `'line'`, `'file'`, `'component'`, `'metadata'`

### Examples

**Only include ID (minimal setup):**
```typescript
componentDebugger({
  includeAttributes: ['id']
});
// Result: <button data-dev-id="src/Button.tsx:10:2">Click me</button>
```

**Exclude verbose attributes:**
```typescript
componentDebugger({
  excludeAttributes: ['metadata', 'file', 'component']
});
// Keeps: id, name, path, line
```

### Testing
- Added comprehensive test suite: 15 test cases in `attribute-filtering.test.ts`
- Tests cover allowlist, disallowlist, priority handling, edge cases, and integration
- All existing tests pass - **100% backwards compatible**

### Documentation
- Updated README with configuration table and examples
- Updated CLAUDE.md with new options
- Exported `AttributeName` type for TypeScript users

## Fixes

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)