### PR TITLE
fix: enable auto-release workflow to trigger on PR merges

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Setup pnpm


### PR DESCRIPTION
## Problem
The auto-release workflow doesn't trigger when PRs are merged to `main`. This is because GitHub's `GITHUB_TOKEN` has a security feature that prevents it from triggering new workflows (to avoid infinite loops).

**Example:** PR #7 was merged but no release was created.

## Solution
Use a Personal Access Token (PAT) instead of `GITHUB_TOKEN` for git operations in the workflow. This allows commits made by the workflow to trigger subsequent workflows.

**Change:**
```yaml
# Before
token: ${{ secrets.GITHUB_TOKEN }}

# After  
token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
```

Falls back to `GITHUB_TOKEN` if PAT isn't configured (workflow still works, just won't trigger subsequent runs).

## Setup Required
To enable auto-triggering, add a PAT to repository secrets:

1. **Create PAT:** https://github.com/settings/tokens/new
   - Name: `vite-plugin-component-debugger-workflow`
   - Scopes: `repo` (all), `workflow`
   - Expiration: No expiration (or max available)

2. **Add to repo secrets:**
   - Go to: https://github.com/canadianeagle/vite-plugin-component-debugger/settings/secrets/actions
   - Click "New repository secret"
   - Name: `PAT`
   - Value: (paste token from step 1)

3. **Test:** Merge this PR and verify auto-release workflow triggers

## Benefits
- ✅ PR merges automatically trigger releases
- ✅ No manual intervention needed
- ✅ Backward compatible (falls back to GITHUB_TOKEN if PAT not set)
- ✅ Follows GitHub's recommended approach for workflow chaining

## References
- [GitHub Docs: Triggering workflows from workflows](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)
- [Using PAT for checkout](https://github.com/actions/checkout#usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>