### PR TITLE
fix: release v2.3.0 and repair the auto-release version check

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -96,14 +96,23 @@ jobs:
         id: check_version
         run: |
           CURRENT_VERSION=$(node -p "require('./package.json').version")
+          PKG_NAME=$(node -p "require('./package.json').name")
           echo "Current version: $CURRENT_VERSION"
 
-          # Check if tag already exists
-          if git rev-parse "v$CURRENT_VERSION" >/dev/null 2>&1; then
-            echo "Tag v$CURRENT_VERSION already exists"
+          # Bump if this version is already ON NPM. The registry is the source of
+          # truth for "has this shipped".
+          #
+          # This used to test for a local git tag instead, which silently skipped
+          # the bump whenever a version had no tag: the workflow would detect a
+          # minor bump, ignore it, and then try to republish the current version.
+          if npm view "$PKG_NAME@$CURRENT_VERSION" version >/dev/null 2>&1; then
+            echo "$CURRENT_VERSION is already published, bumping"
+            echo "needs_bump=true" >> $GITHUB_OUTPUT
+          elif git rev-parse "v$CURRENT_VERSION" >/dev/null 2>&1; then
+            echo "Tag v$CURRENT_VERSION already exists, bumping"
             echo "needs_bump=true" >> $GITHUB_OUTPUT
           else
-            echo "Tag v$CURRENT_VERSION does not exist"
+            echo "$CURRENT_VERSION is unpublished and untagged, releasing as-is"
             echo "needs_bump=false" >> $GITHUB_OUTPUT
             echo "VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
           fi

--- a/changelog.md
+++ b/changelog.md
@@ -5,21 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/canadianeagle/vite-plugin-component-debugger/compare/v2.2.1...HEAD) - 2026-07-26
+> Note: v2.2.1 was tagged but never reached npm; its release run failed to authenticate
+> with the registry. The last published version before this one is v2.2.0.
 
-## [v2.2.1](https://github.com/canadianeagle/vite-plugin-component-debugger/compare/v2.2.0...v2.2.1) - 2026-07-26
 
-- feat: support Vite 2 through 8 ([`4b63c39`](https://github.com/canadianeagle/vite-plugin-component-debugger/commit/4b63c39c1301256866db8222b0aa17c00e354ef0)) by 
-- test: add regression and adversarial suites ([`da1d87a`](https://github.com/canadianeagle/vite-plugin-component-debugger/commit/da1d87aa68efa56a21d802bf18ed96367fd15b10)) by 
-- docs: correct inaccurate claims and document Vite support ([`e068962`](https://github.com/canadianeagle/vite-plugin-component-debugger/commit/e0689626d795988921773bd2e1587dca6b4f73a0)) by 
-- fix: correct 15 defects in attribute generation and file handling ([`cd8f521`](https://github.com/canadianeagle/vite-plugin-component-debugger/commit/cd8f5212b993a41f7cbe0d1063ee0c339877991c)) by 
-- ci: make lint and typecheck real gates, add vite-compat job ([`3e52858`](https://github.com/canadianeagle/vite-plugin-component-debugger/commit/3e528586a4c4cdf9096c59f08af9a39a8a737962)) by 
-- chore: update changelog for v2.2.0 [skip ci] ([`cc73317`](https://github.com/canadianeagle/vite-plugin-component-debugger/commit/cc73317d8d89bd37edec6d2e6d152981de0e5bcb)) by 
-- Update readme.md ([`d0c8fd5`](https://github.com/canadianeagle/vite-plugin-component-debugger/commit/d0c8fd56cc23d2aa80b3691341bb660f2694d5f3)) by 
-- chore: release v2.2.1 [skip ci] ([`edad9a9`](https://github.com/canadianeagle/vite-plugin-component-debugger/commit/edad9a94db2a9620279411936e59aa55a26a4de5)) by 
-- fix: bundle estree-walker so the CommonJS entry works ([`6a3c8fc`](https://github.com/canadianeagle/vite-plugin-component-debugger/commit/6a3c8fcc377b719b212a2f08275cae4c86cdbc3c)) by 
-
-## [Unreleased](https://github.com/canadianeagle/vite-plugin-component-debugger/compare/v2.2.1...HEAD)
+## [v2.3.0](https://github.com/canadianeagle/vite-plugin-component-debugger/compare/v2.2.0...v2.3.0) - 2026-07-26
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-component-debugger",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-component-debugger",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.24.0",
@@ -31,7 +31,7 @@
         "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-component-debugger",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Highly customizable Vite plugin that adds data attributes to JSX/TSX elements for development tracking, debugging, and testing. Features path filtering, transformers, presets, and more.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Follow-up to #11. The merge succeeded but the release did not, for two separate reasons.

## The workflow bug

`auto-release.yml` decided whether to bump the version by checking for a local git tag:

```bash
if git rev-parse "v$CURRENT_VERSION" >/dev/null 2>&1; then needs_bump=true
else needs_bump=false
```

Any version without a tag was treated as already-correct. So the run for #11 correctly logged `Detected MINOR version bump`, then threw that away and tried to publish the current version unchanged.

Now it asks the registry whether the version has actually shipped, with the tag check kept as a fallback.

## Fallout being cleaned up

- **v2.2.1 was tagged but never published.** npm's latest is still **2.2.0**. The October release run failed the same way.
- The failed run appended a generated commit dump to `changelog.md`, which is removed here.

## This release

Version set explicitly to **2.3.0** (minor, for Vite 2-8 support), with the Unreleased section folded into a v2.3.0 entry.

## ⚠️ NPM_TOKEN needs rotating

The publish step failed with:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/vite-plugin-component-debugger
```

A 404 on `PUT` is how npm reports an **unauthenticated** publish; it does not mean the package is missing. The `NPM_TOKEN` secret is invalid or expired and has been since at least October. This cannot be fixed in code. Until it is replaced, merging will build and tag correctly but the publish step will keep failing.

To fix: `npm token create --type=automation`, then update the `NPM_TOKEN` repo secret.

## Verification

lint PASS, `tsc --noEmit` PASS, 1268/1268 tests, build PASS, CJS + ESM entries import, all 7 Vite majors verified, lockfile passes `--frozen-lockfile`.