### PR TITLE
ci: fail the release before tagging when npm auth is broken

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -68,6 +68,27 @@ jobs:
       - name: Build package
         run: pnpm run build
 
+      # Fail before tagging, not after. Publishing is the LAST step, so a dead
+      # NPM_TOKEN used to leave a git tag and a GitHub Release pointing at a
+      # version that never reached the registry. v2.2.1 sat in that state for
+      # nine months and looked shipped.
+      - name: Preflight - verify npm credentials
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error::NPM_TOKEN secret is not set. Nothing would be published."
+            exit 1
+          fi
+
+          if ! WHO=$(npm whoami 2>&1); then
+            echo "::error::NPM_TOKEN is set but not accepted by the registry (npm said: ${WHO})."
+            echo "::error::npm reports an unauthenticated publish as '404 Not Found - PUT', which is misleading."
+            echo "::error::Create a new token with 'npm token create --type=automation' and update the NPM_TOKEN secret."
+            exit 1
+          fi
+          echo "Authenticated to npm as: ${WHO}"
+
       - name: Configure Git
         run: |
           git config --local user.email "action@github.com"
@@ -183,6 +204,21 @@ jobs:
         run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Trust the registry, not the exit code.
+      - name: Verify the version is actually on npm
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          for attempt in 1 2 3 4 5; do
+            if npm view "${PKG_NAME}@${{ env.VERSION }}" version >/dev/null 2>&1; then
+              echo "Confirmed ${PKG_NAME}@${{ env.VERSION }} is live on npm"
+              exit 0
+            fi
+            echo "Not visible yet (attempt ${attempt}/5), waiting for registry propagation..."
+            sleep 10
+          done
+          echo "::error::${PKG_NAME}@${{ env.VERSION }} is not on the registry after publishing."
+          exit 1
 
       - name: Success notification
         run: |


### PR DESCRIPTION
## Why

`NPM_TOKEN` is set in repo secrets (last updated 2025-09-19) but the registry no longer accepts it.

Timeline:
- v2.2.0 published fine **2025-10-07** (token working)
- next release attempt **2025-10-14** failed `E404`
- every attempt since has failed identically, including both runs today

That window matches npm's mass revocation of classic tokens after the September 2025 supply-chain attacks.

## The bug this PR fixes

Publishing is the **last** step, after the git tag and GitHub Release are already created. So a dead token produces a tag and a Release for a version that never reached npm.

**v2.2.1 has been in exactly that state for nine months.** It has a tag and a GitHub Release. It is not on npm. npm's latest is still 2.2.0. The `package.json` claimed 2.2.1 the whole time.

## Changes

- **Preflight before tagging.** Runs `npm whoami` with the token as step 5, before the tag (11) and Release (13). A broken token now fails fast instead of leaving a half-released state.
- **Post-publish verification.** Asks the registry whether the version is actually live, with retries for propagation, rather than trusting the exit code.
- The error message explains that npm reports an unauthenticated publish as `404 Not Found - PUT`, which reads like a missing package rather than an auth failure. That is what made this hard to diagnose.

## This does not fix the token

The token still needs replacing before anything can publish:

```bash
npm token create --type=automation
```

Then update the `NPM_TOKEN` repo secret and re-run the failed Auto Release job for v2.3.0.

Worth considering instead: npm **trusted publishing** via OIDC removes the token entirely, so it cannot expire or leak. It needs a one-time setup on npmjs.com plus `id-token: write` here. Happy to wire that up if you want it.