### PR TITLE
ci: publish via npm trusted publishing (OIDC) with token fallback

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
   packages: write
+  # Required for npm trusted publishing (OIDC). Lets the job mint a short-lived
+  # identity token so npm can verify the publish came from this repo and this
+  # workflow, with no long-lived NPM_TOKEN involved.
+  id-token: write
 
 jobs:
   test:
@@ -72,19 +76,35 @@ jobs:
       # NPM_TOKEN used to leave a git tag and a GitHub Release pointing at a
       # version that never reached the registry. v2.2.1 sat in that state for
       # nine months and looked shipped.
-      - name: Preflight - verify npm credentials
+      # npm >= 11.5.1 is required for OIDC trusted publishing. The Node 18 runner
+      # ships npm 10, so upgrade before we rely on it.
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@latest
+          echo "npm $(npm --version)"
+
+      - name: Preflight - verify a publish route exists
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "::error::NPM_TOKEN secret is not set. Nothing would be published."
-            exit 1
+          # Route 1: OIDC trusted publishing. Preferred, nothing to expire.
+          if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "OIDC is available; publishing via trusted publisher."
+            echo "If npm rejects it, confirm the trusted publisher on npmjs.com names"
+            echo "this repo and workflow file exactly (auto-release.yml)."
+            exit 0
           fi
 
+          # Route 2: a classic/granular token. Being deprecated by npm
+          # (bypass-2FA restricted Aug 2026, direct publishing Jan 2027).
+          echo "::warning::OIDC unavailable, falling back to NPM_TOKEN."
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error::No OIDC and no NPM_TOKEN. Nothing would be published."
+            exit 1
+          fi
           if ! WHO=$(npm whoami 2>&1); then
-            echo "::error::NPM_TOKEN is set but not accepted by the registry (npm said: ${WHO})."
+            echo "::error::NPM_TOKEN is set but the registry rejected it (npm said: ${WHO})."
             echo "::error::npm reports an unauthenticated publish as '404 Not Found - PUT', which is misleading."
-            echo "::error::Create a new token with 'npm token create --type=automation' and update the NPM_TOKEN secret."
             exit 1
           fi
           echo "Authenticated to npm as: ${WHO}"
@@ -200,8 +220,11 @@ jobs:
           draft: false
           prerelease: false
 
+      # Uses npm, not pnpm: OIDC trusted publishing is implemented in the npm CLI.
+      # NODE_AUTH_TOKEN stays as a fallback for when OIDC is unavailable; npm
+      # prefers the trusted publisher when one is configured.
       - name: Publish to NPM
-        run: pnpm publish --access public --no-git-checks
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Why

`NPM_TOKEN` has been rejected with `401 Unauthorized` since October 2025. npm has since removed classic tokens entirely, and granular tokens that bypass 2FA are on a deprecation clock: restricted for account changes **Aug 2026**, for direct publishing **Jan 2027**. npm's own token page now says to use trusted publishing for CI/CD instead.

## What this does

Trusted publishing has the release job mint a short-lived OIDC identity token that npm verifies against a publisher registered for this repo and workflow file. Nothing long-lived is stored, so there is nothing to expire, rotate, or leak.

- adds `id-token: write`
- upgrades npm before publishing, since OIDC needs npm >= 11.5.1 and the Node 18 runner ships npm 10
- publishes with `npm publish` rather than `pnpm publish`, because OIDC trusted publishing is implemented in the npm CLI
- the preflight accepts **either** route: OIDC when available, otherwise a valid `NPM_TOKEN`, so the token path keeps working during the transition

## Requires one manual step

A trusted publisher must be registered on npmjs.com for the package:

- Publisher: GitHub Actions
- `canadianeagle` / `vite-plugin-component-debugger`
- Workflow filename: `auto-release.yml`
- Allowed action: `npm publish`

That form was filled in and is pending a 2FA confirmation. Until it is saved, this PR changes nothing about the outcome; the preflight will simply report that OIDC is available and npm will reject the publish with a clear error naming the mismatch.