### PR TITLE
fix: run the release job on Node 22 so npm can be upgraded for OIDC

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -62,7 +62,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          # Node 22 for the release job specifically: npm >= 11.5.1 is required
+          # for OIDC trusted publishing and it will not install on Node 18.
+          # This does not change the package's own Node 18 support, which is
+          # declared in engines and exercised by the test matrix above.
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
@@ -80,7 +84,8 @@ jobs:
       # ships npm 10, so upgrade before we rely on it.
       - name: Upgrade npm for trusted publishing
         run: |
-          npm install -g npm@latest
+          # Pinned to 11.x: npm@latest is 12.x, which requires Node >= 22.22.
+          npm install -g npm@^11
           echo "npm $(npm --version)"
 
       - name: Preflight - verify a publish route exists


### PR DESCRIPTION
The release job pinned Node 18, and `npm install -g npm@latest` now resolves to **npm 12**, which requires `^22.22.2 || ^24.15.0 || >=26`. It failed with `EBADENGINE` before reaching the publish step.

Runs the release job on **Node 22** and pins the upgrade to **npm 11.x**, which is recent enough for OIDC trusted publishing (needs >= 11.5.1) and installs cleanly there.

Does not narrow support for the published package: `engines.node` still says `>=18.12.0` and the test matrix still covers 18, 20 and 22.