### PR TITLE
fix: stop the release failing when pnpm version already created the tag

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -176,11 +176,19 @@ jobs:
         run: |
           git push origin main
 
+      # `pnpm version` in the bump step already creates this tag, so creating it
+      # again is a fatal error. That made every bump-path release fail; v2.3.0
+      # only got through because it needed no bump, so `pnpm version` never ran.
       - name: Create and push tag
         run: |
-          git tag v${{ env.VERSION }}
-          git push origin v${{ env.VERSION }}
-          echo "Created and pushed tag v${{ env.VERSION }}"
+          if git rev-parse "v${{ env.VERSION }}" >/dev/null 2>&1; then
+            echo "Tag v${{ env.VERSION }} already exists locally (created by pnpm version)"
+          else
+            git tag "v${{ env.VERSION }}"
+            echo "Created tag v${{ env.VERSION }}"
+          fi
+          git push origin "v${{ env.VERSION }}"
+          echo "Pushed tag v${{ env.VERSION }}"
 
       - name: Generate changelog and update file
         run: |


### PR DESCRIPTION
## What broke

Merging #18 kicked off a v2.3.1 release. It failed:

```
fatal: tag 'v2.3.1' already exists
```

`pnpm version <type>` creates **both** the version commit and the git tag. The next step then ran `git tag v$VERSION` unconditionally.

## Why nobody noticed until now

The bump path had never actually worked. **v2.3.0 shipped only because it needed no bump** (it was unpublished and untagged, so `needs_bump=false` and `pnpm version` never ran). The very first release that genuinely needed a bump hit this.

## Current state

The version-bump commit was pushed to main before the failure, so `package.json` says **2.3.1** while npm's latest is **2.3.0**. No phantom tag or GitHub Release was created, because the failure happened before either. The preflight and registry-based version check both did their jobs.

## Fix

The tag step now creates the tag only if it does not already exist, then pushes it either way.

Once merged, the next run should publish 2.3.1 cleanly: it is unpublished and untagged, so it releases as-is.